### PR TITLE
fix warning & string update

### DIFF
--- a/src/beta-2024/src/symbols.rs
+++ b/src/beta-2024/src/symbols.rs
@@ -343,7 +343,7 @@ fn type_to_ide_string(sp!(_, t): &Type) -> String {
             for ty in vec_ty.iter() {
                 result_string = format!("{} + {}", result_string, type_to_ide_string(ty));
             }
-            format!("{} + {}", result_string, type_to_ide_string(box_ty.as_ref()));
+            result_string = format!("{} + {}", result_string, type_to_ide_string(box_ty.as_ref()));
             result_string
         },
         Type_::Anything => "_".to_string(),


### PR DESCRIPTION
Fix the following warning
```bash
warning: unused return value of `std::hint::must_use` that must be used
   --> src/beta-2024/src/symbols.rs:346:13
    |
346 |             format!("{} + {}", result_string, type_to_ide_string(box_ty.as_ref()));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: this warning originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `beta-2024` (lib) generated 1 warning
```